### PR TITLE
Fix to handle ssh options

### DIFF
--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -5,19 +5,19 @@ describe Net::SSH::Session do
     context 'with :timeout option' do
       it 'raises error if timeout value is not numeric' do
         expect {
-          Net::SSH::Session.new('host', 'user', 'password', :timeout => 'data')
+          Net::SSH::Session.new('host', 'user', :password=>'password', :timeout => 'data')
         }.to raise_error ArgumentError, "Timeout value should be numeric"
       end
 
       it 'sets global session timeout value' do
-        session = Net::SSH::Session.new('host', 'user', 'password', :timeout => 1)
+        session = Net::SSH::Session.new('host', 'user', :password=>'password', :timeout => 1)
         expect(session.timeout).to eq 1
       end
     end
   end 
 
   describe '#method_missing' do
-    let(:session) { Net::SSH::Session.new('host', 'user', 'password') }
+    let(:session) { Net::SSH::Session.new('host', 'user', :password=>'password') }
     before { session.stub(:run).with("uname").and_return(fake_run("uname", "Linux")) }
 
     it 'runs a command based on missing method name' do
@@ -32,7 +32,7 @@ describe Net::SSH::Session do
       end
 
       let(:session) do
-        Net::SSH::Session.new('host', 'user', 'password', :timeout => 1)
+        Net::SSH::Session.new('host', 'user', :password=>'password', :timeout => 1)
       end
 
       before do


### PR DESCRIPTION
Added the ability to use options provided in the initialisation(Net::SSH::Session.new).

One use case for the change would be when authenticating using public-private key files. The base library (Net::SSH) supports such mechanism, the provided options hash is transparently passed down to base libraries.

Below are few ways in which suggested change enables initialisation.

using host,username & password
`session = Net::SSH::Session.new('host', 'user', :password=>'password')`

using host, username  & private key
`session = Net::SSH::Session.new('host', 'user', :keys=>'/path/to/private/key/file')`

loading default openssh config file(~/.ssh/config)
`session = Net::SSH::Session.new('host', 'user', :config=>true)`
